### PR TITLE
tools: Fixes bug where clang-tidy assumes cc flags

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,3 +15,6 @@ coverage --combined_report=lcov
 coverage --experimental_use_llvm_covmap
 coverage --experimental_generate_llvm_lcov
 coverage --incompatible_cc_coverage
+
+# Static analyser support 
+build:analyser --aspects //tools/clang_tidy:clang_tidy.bzl%clang_tidy_aspect --output_groups=report 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -21,3 +21,8 @@ cc_binary(
     name = "dereferencing_null_pointer",
     srcs = ["dereferencing_null_pointer.cc"],
 )
+
+cc_binary(
+    name = "c_only",
+    srcs = ["c_only.c"],
+)

--- a/tests/c_only.c
+++ b/tests/c_only.c
@@ -1,0 +1,6 @@
+#ifdef __cplusplus
+#error \
+    "This is the C file, this file should not be compiled with -xc++ \
+    language directives."
+#endif
+int main() { return 0; }

--- a/tools/clang_tidy/clang_tidy.bzl
+++ b/tools/clang_tidy/clang_tidy.bzl
@@ -16,7 +16,7 @@ def _language(file):
     Args:
         file (File): The file to get the language for
     """
-    if file.extension == ".c":
+    if file.extension == "c":
         return "c"
     else:
         return "cc"


### PR DESCRIPTION
A minor bug was introduced where the clang-tidy tooling would always
assume that it was compiling for c++ even when compiling a c source
file. This change fixes this bug, and additionally adds regression
tests.