### PR TITLE
Update clang to 15.0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Fetch external test deps
         run: |
           bazelisk --bazelrc=ci.bazelrc fetch @com_google_googletest//... \
-            @com_github_google_benchmark//... \
             @com_google_absl//...
 
   build_and_test:
@@ -43,7 +42,6 @@ jobs:
       matrix:
         lib:
           - "@com_google_googletest//..."
-          - "@com_github_google_benchmark//..."
           - "@com_google_absl//..."
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,29 +15,9 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
 
-  fetch_test_deps:
-    runs-on: ubuntu-20.04
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-
-      - name: Mount bazel repository cache
-        uses: actions/cache@v3
-        with:
-          path: "~/bazel/repository_cache"
-          key: ${{ runner.os }}-bazel
-
-      - name: Fetch external test deps
-        run: |
-          bazelisk --bazelrc=ci.bazelrc fetch @com_google_googletest//... \
-            @com_google_absl//...
-
   build_and_test:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
-    needs: fetch_test_deps
     strategy:
       matrix:
         lib:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           bazelisk --bazelrc=ci.bazelrc test ${{ matrix.lib }}
           bazelisk --bazelrc=ci.bazelrc build ${{ matrix.lib }}
-          bazelisk --bazelrc=ci.bazelrc --config analyser build ${{ matrix.lib }}
+          bazelisk --bazelrc=ci.bazelrc build --config analyser ${{ matrix.lib }}
 
   ci-success:
     name: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           bazelisk --bazelrc=ci.bazelrc test ${{ matrix.lib }}
           bazelisk --bazelrc=ci.bazelrc build ${{ matrix.lib }}
-          bazelisk --bazelrc=ci.bazelrc build ${{ matrix.lib }} --config analyser
+          bazelisk --bazelrc=ci.bazelrc --config analyser build ${{ matrix.lib }}
 
   ci-success:
     name: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
       matrix:
         lib:
           - "@com_google_googletest//..."
-          - "@com_google_absl//..."
+          # Some tests are excluded because of
+          # https://github.com/abseil/abseil-cpp/issues/1378
+          - "-- @com_google_absl//... -@com_google_absl//absl/time:time_test -@com_google_absl//absl/time/internal/cctz:time_zone_format_test -@com_google_absl//absl/time/internal/cctz:time_zone_lookup_test -@com_google_absl//absl/time:time_benchmark"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rules_cc_toolchain
 [![CI](https://github.com/silvergasp/bazel_rules_cc_toolchain/actions/workflows/blank.yml/badge.svg)](https://github.com/silvergasp/bazel_rules_cc_toolchain/actions/workflows/blank.yml)
 
-An opinionated hermetic host toolchain for Bazel and C++. Currently this 
+An opinionated hermetic host toolchain for Bazel and C++. Currently this
 toolchain supports;
 - Completely sandboxed linux builds (i.e. no system deps).
 - Code coverage and combined lcov reports e.g.
@@ -15,6 +15,8 @@ The toolchain is modular enough that you should be able to BYO;
 - libc++ / libc++abi
 - Startup libraries (e.g. crt1.o)
 - Injected toolchain headers and libs
+
+
 ## Getting Started
 Add the following to your workspace file;
 
@@ -55,14 +57,14 @@ coverage --incompatible_cc_coverage
 ```
 
 ## Defaults and config
-This repository provides a set of sane defaults to make up a 
+This repository provides a set of sane defaults to make up a
 [complete toolchain](https://clang.llvm.org/docs/Toolchain.html). By default;
 
 | Library           | Provider                                           |
 | ----------------- | -------------------------------------------------- |
 | libc              | Debian stretch sysroot (GNU glibc6)                |
-| libc++            | LLVM 15.0.7 libc++                                 |
-| libc++abi         | LLVM 15.0.7 libc++abi                              |
+| libc++            | LLVM 15.0.6 libc++                                 |
+| libc++abi         | LLVM 15.0.6 libc++abi                              |
 | libunwind         | Debian stretch sysroot (GNU gcc6 compiler runtime) |
 | Startup Libraries | Debian stretch libcrt (GNU glibc6)                 |
 
@@ -70,9 +72,9 @@ This can be viewed in more detail by inspecting `//config/config:BUILD.bazel`.
 
 
 ## Bring your own system libraries (Advanced)
-This toolchain supports bringing your own precompiled system libraries. 
+This toolchain supports bringing your own precompiled system libraries.
 Implementing this can be somewhat complicated and it is unlikely that we will
-support specific combinations of libraries on request, although PR's here are 
+support specific combinations of libraries on request, although PR's here are
 welcome.
 
 An example of how you might include your own version of libc++ is shown below.
@@ -80,15 +82,15 @@ An example of how you might include your own version of libc++ is shown below.
 Add a third_party dependency directory for your libc++ build definitions.
 ``` sh
 mkdir third_party
-touch third_party/clang_llvm_15_06_x86_64_linux_gnu_ubuntu_18_04.BUILD
+touch third_party/clang_llvm_x86_64_linux_gnu_ubuntu.BUILD
 ```
 
 Add the following to your WORKSPACE file.
 ``` py
 # WORKSPACE
 http_archive(
-    name = "clang_llvm_15_06_x86_64_linux_gnu_ubuntu_18_04",
-    build_file = "//third_party:clang_llvm_15_06_x86_64_linux_gnu_ubuntu_18_04.BUILD",
+    name = "clang_llvm_x86_64_linux_gnu_ubuntu",
+    build_file = "//third_party:clang_llvm_x86_64_linux_gnu_ubuntu.BUILD",
     sha256 = "9694f4df031c614dbe59b8431f94c68631971ad44173eecc1ea1a9e8ee27b2a3",
     strip_prefix = "clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04",
     url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz",
@@ -98,7 +100,7 @@ http_archive(
 From here you will need to add in your definitions that specify the library
 files that are provided by this implementation of libc++.
 ``` py
-# third_party:clang_llvm_15_06_x86_64_linux_gnu_ubuntu_18_04.BUILD
+# third_party:clang_llvm_x86_64_linux_gnu_ubuntu.BUILD
 load(
     "@rules_cc_toolchain//cc_toolchain:cc_toolchain_import.bzl",
     "cc_toolchain_import",
@@ -110,8 +112,8 @@ cc_toolchain_import(
     hdrs = glob(["include/c++/v1/**"]),
     # It is common for a library e.g. libc++.so to actually just be a linker
     # script that points to a different library as is the case here where,
-    # 'lib/libc++.so' is a linker script that points to 'lib/libc++.so.1'. 
-    # This is done so that dynamic linker can ensure that it is linking 
+    # 'lib/libc++.so' is a linker script that points to 'lib/libc++.so.1'.
+    # This is done so that dynamic linker can ensure that it is linking
     # against a compatible version of the library ABI (in this case version 1).
     additional_libs = [
         "lib/libc++.so.1",
@@ -119,15 +121,15 @@ cc_toolchain_import(
     includes = ["include/c++/v1"],
 
     # NOTE: If one of static_library or shared_library is omitted this toolchain
-    # will default to the other. This is useful if you want to static link a 
-    # particular library. It is also possible to omit both static_library and 
+    # will default to the other. This is useful if you want to static link a
+    # particular library. It is also possible to omit both static_library and
     # shared_library, creating a header only toolchain lib.
     # Use with statically linkage.
     static_library = "lib/libc++.a",
     # Use with shared linkage.
     shared_library = "lib/libc++.so",
 
-    # This is a usefult sanity check to say that this library can only be 
+    # This is a usefult sanity check to say that this library can only be
     # targetted at Linux on an x86 machine.
     target_compatible_with = select({
         "@platforms//os:linux": ["@platforms//cpu:x86_64"],
@@ -140,7 +142,7 @@ cc_toolchain_import(
     # This version of libc++ depends on libc and libunwind, by specifying the
     # dependency on the configuration layer rather than directly on the imported
     # library itself we can ensure that we can swap out the version of libc with
-    # little effort. 
+    # little effort.
     deps = [
         "@rules_cc_toolchain_config//:libc",
         "@rules_cc_toolchain_config//:libunwind",
@@ -148,16 +150,16 @@ cc_toolchain_import(
 )
 ```
 
-Now we can test the new toolchain to ensure that it functions correctly. 
+Now we can test the new toolchain to ensure that it functions correctly.
 ``` sh
 bazel coverage @rules_cc_toolchain//tests/... \
- --@rules_cc_toolchain_config//:libc++=@clang_llvm_15_06_x86_64_linux_gnu_ubuntu_18_04//:llvm_libcxx
+ --@rules_cc_toolchain_config//:libc++=@clang_llvm_x86_64_linux_gnu_ubuntu//:llvm_libcxx
 ```
 
-**NOTE:** While the toolchain itself is hermetic the runtime linkage is not in 
+**NOTE:** While the toolchain itself is hermetic the runtime linkage is not in
 this example you will need to make sure that you have a recent version of LLVMs
 libc++ installed on your system. If you would like to make sure that your
-runtime is hermetic use the static linking mode in Bazel, or simply omit the 
+runtime is hermetic use the static linking mode in Bazel, or simply omit the
 shared_library attribute to disable shared linkage for that specific library.
 
 You can also opt to make these changes permanent by overriding the
@@ -173,11 +175,11 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "clang_llvm_15_06_x86_64_linux_gnu_ubuntu_18_04",
-    build_file = "//third_party:clang_llvm_15_06_x86_64_linux_gnu_ubuntu_18_04.BUILD",
+    name = "clang_llvm_x86_64_linux_gnu_ubuntu",
+    build_file = "//third_party:clang_llvm_x86_64_linux_gnu_ubuntu.BUILD",
     sha256 = "9694f4df031c614dbe59b8431f94c68631971ad44173eecc1ea1a9e8ee27b2a3",
-    strip_prefix = "clang+llvm-15.0.7-x86_64-linux-gnu-ubuntu-16.04",
-    url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-linux-gnu-ubuntu-16.04.tar.xz",
+    strip_prefix = "clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04",
+    url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz",
 )
 
 # Set up host hermetic host toolchain.
@@ -188,7 +190,7 @@ git_repository(
 )
 
 # (NEW)
-load("@rules_cc_toolchain//config:rules_cc_toolchain_config_repository.bzl", 
+load("@rules_cc_toolchain//config:rules_cc_toolchain_config_repository.bzl",
     "rules_cc_toolchain_config")
 
 # (NEW) Must be called before rules_cc_toolchain_deps.
@@ -203,5 +205,20 @@ rules_cc_toolchain_deps()
 
 load("@rules_cc_toolchain//cc_toolchain:cc_toolchain.bzl", "register_cc_toolchains")
 
-register_cc_toolchains() 
+register_cc_toolchains()
 ```
+
+## Upgrading clang version
+
+This repository hardcodes a particular clang version, currently 15.0.6. To
+upgrade, you must:
+
+1.  Update the `CLANG_VERSION` variable in
+    `third_party/clang_llvm_x86_64_linux_gnu_ubuntu.BUILD`.
+2. Update the `clang_llvm_x86_64_linux_gnu_ubuntu` `http_archive` in
+    `rules_cc_toolchain_deps.bzl`.
+
+Ideally, that would be it. Unfortunately, the exact locations of relevant files
+(e.g., static libraries) vary from one clang release to the next. In fact,
+it's not even guaranteed that a x86 Linux binary release will exist for a
+given clang version (https://github.com/llvm/llvm-project/issues/60201)!

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ This repository provides a set of sane defaults to make up a
 | Library           | Provider                                           |
 | ----------------- | -------------------------------------------------- |
 | libc              | Debian stretch sysroot (GNU glibc6)                |
-| libc++            | LLVM 12.0.0 libc++                                 |
-| libc++abi         | LLVM 12.0.0 libc++abi                              |
+| libc++            | LLVM 15.0.7 libc++                                 |
+| libc++abi         | LLVM 15.0.7 libc++abi                              |
 | libunwind         | Debian stretch sysroot (GNU gcc6 compiler runtime) |
 | Startup Libraries | Debian stretch libcrt (GNU glibc6)                 |
 
@@ -80,25 +80,25 @@ An example of how you might include your own version of libc++ is shown below.
 Add a third_party dependency directory for your libc++ build definitions.
 ``` sh
 mkdir third_party
-touch third_party/clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04.BUILD
+touch third_party/clang_llvm_15_06_x86_64_linux_gnu_ubuntu_18_04.BUILD
 ```
 
 Add the following to your WORKSPACE file.
 ``` py
 # WORKSPACE
 http_archive(
-    name = "clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04",
-    build_file = "//third_party:clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04.BUILD",
+    name = "clang_llvm_15_06_x86_64_linux_gnu_ubuntu_18_04",
+    build_file = "//third_party:clang_llvm_15_06_x86_64_linux_gnu_ubuntu_18_04.BUILD",
     sha256 = "9694f4df031c614dbe59b8431f94c68631971ad44173eecc1ea1a9e8ee27b2a3",
-    strip_prefix = "clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-16.04",
-    url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.0/clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz",
+    strip_prefix = "clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04",
+    url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz",
 )
 ```
 
 From here you will need to add in your definitions that specify the library
 files that are provided by this implementation of libc++.
 ``` py
-# third_party:clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04.BUILD
+# third_party:clang_llvm_15_06_x86_64_linux_gnu_ubuntu_18_04.BUILD
 load(
     "@rules_cc_toolchain//cc_toolchain:cc_toolchain_import.bzl",
     "cc_toolchain_import",
@@ -151,7 +151,7 @@ cc_toolchain_import(
 Now we can test the new toolchain to ensure that it functions correctly. 
 ``` sh
 bazel coverage @rules_cc_toolchain//tests/... \
- --@rules_cc_toolchain_config//:libc++=@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:llvm_libcxx
+ --@rules_cc_toolchain_config//:libc++=@clang_llvm_15_06_x86_64_linux_gnu_ubuntu_18_04//:llvm_libcxx
 ```
 
 **NOTE:** While the toolchain itself is hermetic the runtime linkage is not in 
@@ -173,11 +173,11 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04",
-    build_file = "//third_party:clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04.BUILD",
+    name = "clang_llvm_15_06_x86_64_linux_gnu_ubuntu_18_04",
+    build_file = "//third_party:clang_llvm_15_06_x86_64_linux_gnu_ubuntu_18_04.BUILD",
     sha256 = "9694f4df031c614dbe59b8431f94c68631971ad44173eecc1ea1a9e8ee27b2a3",
-    strip_prefix = "clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-16.04",
-    url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.0/clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz",
+    strip_prefix = "clang+llvm-15.0.7-x86_64-linux-gnu-ubuntu-16.04",
+    url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-linux-gnu-ubuntu-16.04.tar.xz",
 )
 
 # Set up host hermetic host toolchain.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ cc_toolchain_import(
     # particular library. It is also possible to omit both static_library and
     # shared_library, creating a header only toolchain lib.
     # Use with statically linkage.
-    static_library = "lib/libc++.a",
+    static_library = "lib/x86_64-unknown-linux-gnu/libc++.a",
     # Use with shared linkage.
     shared_library = "lib/libc++.so",
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,12 +10,10 @@ load("//:rules_cc_toolchain_deps.bzl", "rules_cc_toolchain_deps")
 # Required by: rules_cc_toolchain.
 # Required by modules: tools.
 http_archive(
-    name = "bazel_skylib",
-    sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
-    urls = [
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
-    ],
+    name = "bazel_skylib",  # 2022-09-01
+    sha256 = "4756ab3ec46d94d99e5ed685d2d24aece484015e45af303eb3a11cab3cdc2e71",
+    strip_prefix = "bazel-skylib-1.3.0",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/refs/tags/1.3.0.zip"],
 )
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,6 +31,7 @@ git_repository(
     name = "io_bazel_stardoc",
     commit = "8f6d22452d088b49b13ba2c224af69ccc8ccbc90",
     remote = "https://github.com/bazelbuild/stardoc.git",
+    shallow_since = "1620849756 -0400",
 )
 
 # Sets up Bazels packaging rules, for use the document generator.

--- a/cc_toolchain/BUILD.bazel
+++ b/cc_toolchain/BUILD.bazel
@@ -28,7 +28,7 @@ filegroup(
         ":all_imports",
         "//cc_toolchain/features:startup_libs",
         "//cc_toolchain/wrappers:all",
-        "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:all",
+        "@clang_llvm_x86_64_linux_gnu_ubuntu//:all",
     ],
 )
 
@@ -36,7 +36,7 @@ filegroup(
     name = "ar_files",
     srcs = [
         "//cc_toolchain/wrappers:all",
-        "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:ar_files",
+        "@clang_llvm_x86_64_linux_gnu_ubuntu//:ar_files",
     ],
 )
 
@@ -45,7 +45,7 @@ filegroup(
     srcs = [
         ":all_imports",
         "//cc_toolchain/wrappers:all",
-        "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:compiler_files",
+        "@clang_llvm_x86_64_linux_gnu_ubuntu//:compiler_files",
     ],
 )
 
@@ -55,7 +55,7 @@ filegroup(
         ":compiler_files",
         "//cc_toolchain/features:startup_libs",
         "//cc_toolchain/wrappers:all",
-        "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:linker_files",
+        "@clang_llvm_x86_64_linux_gnu_ubuntu//:linker_files",
     ],
 )
 
@@ -63,7 +63,7 @@ filegroup(
     name = "objcopy_files",
     srcs = [
         "//cc_toolchain/wrappers:all",
-        "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:objcopy_files",
+        "@clang_llvm_x86_64_linux_gnu_ubuntu//:objcopy_files",
     ],
 )
 
@@ -71,7 +71,7 @@ filegroup(
     name = "strip_files",
     srcs = [
         "//cc_toolchain/wrappers:all",
-        "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:strip_files",
+        "@clang_llvm_x86_64_linux_gnu_ubuntu//:strip_files",
     ],
 )
 
@@ -91,9 +91,9 @@ cc_toolchain(
 
 cc_toolchain_config(
     name = "linux_x86_64_toolchain_config",
-    archiver = "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:bin/llvm-ar",
-    c_compiler = "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:bin/clang",
-    cc_compiler = "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:bin/clang++",
+    archiver = "@clang_llvm_x86_64_linux_gnu_ubuntu//:bin/llvm-ar",
+    c_compiler = "@clang_llvm_x86_64_linux_gnu_ubuntu//:bin/clang",
+    cc_compiler = "@clang_llvm_x86_64_linux_gnu_ubuntu//:bin/clang++",
     compiler_features = [
         # Hermetic libraries feature required before import.
         "//cc_toolchain/features:hermetic_libraries",
@@ -121,9 +121,9 @@ cc_toolchain_config(
         "//cc_toolchain/features:c++17",
         "//cc_toolchain/features:c++20",
     ],
-    linker = "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:bin/ld.lld",
-    object_dump_tool = "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:bin/llvm-objdump",
-    symbol_list_tool = "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:bin/llvm-nm",
+    linker = "@clang_llvm_x86_64_linux_gnu_ubuntu//:bin/ld.lld",
+    object_dump_tool = "@clang_llvm_x86_64_linux_gnu_ubuntu//:bin/llvm-objdump",
+    symbol_list_tool = "@clang_llvm_x86_64_linux_gnu_ubuntu//:bin/llvm-nm",
 )
 
 toolchain(

--- a/cc_toolchain/wrappers/posix/gcov
+++ b/cc_toolchain/wrappers/posix/gcov
@@ -25,4 +25,4 @@
 set -euo pipefail
 # TODO(issues/4): make this compiler independant currently no easy way to do
 # this via features/actions configs.
-external/clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04/bin/llvm-profdata $@
+external/clang_llvm_x86_64_linux_gnu_ubuntu/bin/llvm-profdata $@

--- a/cc_toolchain/wrappers/posix/llvm-cov
+++ b/cc_toolchain/wrappers/posix/llvm-cov
@@ -25,4 +25,4 @@
 set -euo pipefail
 # TODO(issues/4): make this compiler independant currently no easy way to do
 # this via features/actions configs.
-external/clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04/bin/llvm-cov $@
+external/clang_llvm_x86_64_linux_gnu_ubuntu/bin/llvm-cov $@

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -57,6 +57,13 @@ alias(
 )
 
 alias(
+    name = "llvm_config_site_multiplexer",
+    actual = select({
+        ":linux_x86_64": "@clang_llvm_x86_64_linux_gnu_ubuntu//:llvm_config_site",
+    }),
+)
+
+alias(
     name = "startup_libs",
     actual = select({
         ":linux_x86_64": "@debian_stretch_amd64_sysroot//:startup_libs",

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -38,21 +38,21 @@ alias(
 alias(
     name = "libc++_multiplexer",
     actual = select({
-        ":linux_x86_64": "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:llvm_libcxx",
+        ":linux_x86_64": "@clang_llvm_x86_64_linux_gnu_ubuntu//:llvm_libcxx",
     }),
 )
 
 alias(
     name = "libc++abi_multiplexer",
     actual = select({
-        ":linux_x86_64": "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:llvm_libcxx_abi",
+        ":linux_x86_64": "@clang_llvm_x86_64_linux_gnu_ubuntu//:llvm_libcxx_abi",
     }),
 )
 
 alias(
     name = "libclang_rt_multiplexer",
     actual = select({
-        ":linux_x86_64": "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:llvm_libclang_rt",
+        ":linux_x86_64": "@clang_llvm_x86_64_linux_gnu_ubuntu//:llvm_libclang_rt",
     }),
 )
 

--- a/config/rules_cc_toolchain_config.BUILD
+++ b/config/rules_cc_toolchain_config.BUILD
@@ -3,7 +3,7 @@ package(default_visibility = ["//visibility:public"])
 # Compilers
 label_flag(
     name = "clang",
-    build_setting_default = "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:all",
+    build_setting_default = "@clang_llvm_x86_64_linux_gnu_ubuntu//:all",
 )
 
 # Libraries

--- a/config/rules_cc_toolchain_config.BUILD
+++ b/config/rules_cc_toolchain_config.BUILD
@@ -33,6 +33,11 @@ label_flag(
 )
 
 label_flag(
+    name = "llvm_config_site",
+    build_setting_default = "@rules_cc_toolchain//config:llvm_config_site_multiplexer",
+)
+
+label_flag(
     name = "compiler_rt",
     build_setting_default = "@rules_cc_toolchain//config:libclang_rt_multiplexer",
 )

--- a/rules_cc_toolchain_deps.bzl
+++ b/rules_cc_toolchain_deps.bzl
@@ -39,6 +39,7 @@ def rules_cc_toolchain_deps():
             name = "rules_os",
             commit = "68cdf228f8449a2b42b3a7b6d65395af74a007d7",
             remote = "https://github.com/silvergasp/rules_os.git",
+            shallow_since = "1624010567 +0800",
         )
 
     # Setup x64 linux sysroot

--- a/rules_cc_toolchain_deps.bzl
+++ b/rules_cc_toolchain_deps.bzl
@@ -12,11 +12,11 @@ def rules_cc_toolchain_deps():
     if "platforms" not in native.existing_rules():
         http_archive(
             name = "platforms",
+            sha256 = "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz",
-                "https://github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+                "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
             ],
-            sha256 = "079945598e4b6cc075846f7fd6a9d0857c33a7afc0de868c2ccb96405225135d",
         )
 
     # Setup clang compiler files.

--- a/rules_cc_toolchain_deps.bzl
+++ b/rules_cc_toolchain_deps.bzl
@@ -22,13 +22,13 @@ def rules_cc_toolchain_deps():
     # Setup clang compiler files.
     # Required by: rules_cc_toolchain.
     # Used by modules: cc_toolchain.
-    if "clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04" not in native.existing_rules():
+    if "clang_llvm_x86_64_linux_gnu_ubuntu" not in native.existing_rules():
         http_archive(
-            name = "clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04",
-            url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.0/clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz",
-            sha256 = "9694f4df031c614dbe59b8431f94c68631971ad44173eecc1ea1a9e8ee27b2a3",
-            build_file = "@rules_cc_toolchain//third_party:clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04.BUILD",
-            strip_prefix = "clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-16.04",
+            name = "clang_llvm_x86_64_linux_gnu_ubuntu",
+            url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz",
+            sha256 = "38bc7f5563642e73e69ac5626724e206d6d539fbef653541b34cae0ba9c3f036",
+            build_file = "@rules_cc_toolchain//third_party:clang_llvm_x86_64_linux_gnu_ubuntu.BUILD",
+            strip_prefix = "clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04",
         )
 
     # Setup os normalisation tools.

--- a/third_party/clang_llvm_x86_64_linux_gnu_ubuntu.BUILD
+++ b/third_party/clang_llvm_x86_64_linux_gnu_ubuntu.BUILD
@@ -5,6 +5,8 @@ load(
 
 exports_files(glob(["bin/*"]))
 
+CLANG_VERSION = "15.0.6"
+
 filegroup(
     name = "all",
     srcs = glob(["**/*"]),
@@ -49,7 +51,7 @@ filegroup(
 cc_toolchain_import(
     name = "llvm_libunwind",
     hdrs = glob(["lib/clang/*/include/unwind.h"]),
-    includes = ["lib/clang/15.0.6/include"],
+    includes = ["lib/clang/{clang_version}/include".format(clang_version = CLANG_VERSION)],
     runtime_path = "/usr/lib/x86_64-linux-gnu",
     shared_library = "lib/libunwind.so",
     static_library = "lib/x86_64-unknown-linux-gnu/libunwind.a",
@@ -66,7 +68,7 @@ cc_toolchain_import(
 cc_toolchain_import(
     name = "llvm_libstddef",
     hdrs = glob(["lib/clang/*/include/stddef.h"]),
-    includes = ["lib/clang/15.0.6/include"],
+    includes = ["lib/clang/{clang_version}/include".format(clang_version = CLANG_VERSION)],
     # runtime_path = "/usr/lib/x86_64-linux-gnu",
     # shared_library = "lib/libunwind.so",
     # static_library = "lib/x86_64-unknown-linux-gnu/libunwind.a",
@@ -134,11 +136,10 @@ cc_toolchain_import(
         "lib/clang/*/include/**/*.h",
     ]),
     includes = [
-        "lib/clang/15.0.6",
-        "lib/clang/15.0.6/include",
+        "lib/clang/{clang_version}".format(clang_version = CLANG_VERSION),
+        "lib/clang/{clang_version}/include".format(clang_version = CLANG_VERSION),
     ],
-    # TODO: Last place where the version is hardcoded :/
-    static_library = "lib/clang/15.0.6/lib/x86_64-unknown-linux-gnu/libclang_rt.builtins.a",
+    static_library = "lib/clang/{clang_version}/lib/x86_64-unknown-linux-gnu/libclang_rt.builtins.a".format(clang_version = CLANG_VERSION),
     target_compatible_with = select({
         "@platforms//os:linux": ["@platforms//cpu:x86_64"],
         "//conditions:default": ["@platforms//:incompatible"],

--- a/third_party/clang_llvm_x86_64_linux_gnu_ubuntu.BUILD
+++ b/third_party/clang_llvm_x86_64_linux_gnu_ubuntu.BUILD
@@ -66,23 +66,6 @@ cc_toolchain_import(
 )
 
 cc_toolchain_import(
-    name = "llvm_libstddef",
-    hdrs = glob(["lib/clang/*/include/stddef.h"]),
-    includes = ["lib/clang/{clang_version}/include".format(clang_version = CLANG_VERSION)],
-    # runtime_path = "/usr/lib/x86_64-linux-gnu",
-    # shared_library = "lib/libunwind.so",
-    # static_library = "lib/x86_64-unknown-linux-gnu/libunwind.a",
-    target_compatible_with = select({
-        "@platforms//os:linux": ["@platforms//cpu:x86_64"],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
-    visibility = ["@rules_cc_toolchain//config:__pkg__"],
-    deps = [
-        "@rules_cc_toolchain_config//:libc",
-    ],
-)
-
-cc_toolchain_import(
     name = "llvm_libcxx",
     hdrs = glob(["include/c++/v1/**"]),
     includes = ["include/c++/v1"],
@@ -93,11 +76,9 @@ cc_toolchain_import(
     }),
     visibility = ["@rules_cc_toolchain//config:__pkg__"],
     deps = [
-        # TODO: Add more indirection.
-        ":llvm_config_site",
-        # ":llvm_libstddef",
         "@rules_cc_toolchain_config//:libc",
         "@rules_cc_toolchain_config//:libunwind",
+        "@rules_cc_toolchain_config//:llvm_config_site",
     ],
 )
 

--- a/third_party/clang_llvm_x86_64_linux_gnu_ubuntu.BUILD
+++ b/third_party/clang_llvm_x86_64_linux_gnu_ubuntu.BUILD
@@ -49,7 +49,7 @@ filegroup(
 cc_toolchain_import(
     name = "llvm_libunwind",
     hdrs = glob(["lib/clang/*/include/unwind.h"]),
-    includes = glob(["lib/clang/*/include"]),
+    includes = ["lib/clang/15.0.6/include"],
     runtime_path = "/usr/lib/x86_64-linux-gnu",
     shared_library = "lib/libunwind.so",
     static_library = "lib/x86_64-unknown-linux-gnu/libunwind.a",
@@ -93,7 +93,7 @@ cc_toolchain_import(
     deps = [
         # TODO: Add more indirection.
         ":llvm_config_site",
-        ":llvm_libstddef",
+        # ":llvm_libstddef",
         "@rules_cc_toolchain_config//:libc",
         "@rules_cc_toolchain_config//:libunwind",
     ],
@@ -133,10 +133,10 @@ cc_toolchain_import(
         "lib/clang/*/include/*.h",
         "lib/clang/*/include/**/*.h",
     ]),
-    includes = glob([
-        "lib/clang/*",
-        "lib/clang/*/include",
-    ]),
+    includes = [
+        "lib/clang/15.0.6",
+        "lib/clang/15.0.6/include",
+    ],
     # TODO: Last place where the version is hardcoded :/
     static_library = "lib/clang/15.0.6/lib/x86_64-unknown-linux-gnu/libclang_rt.builtins.a",
     target_compatible_with = select({

--- a/third_party/clang_llvm_x86_64_linux_gnu_ubuntu.BUILD
+++ b/third_party/clang_llvm_x86_64_linux_gnu_ubuntu.BUILD
@@ -48,11 +48,11 @@ filegroup(
 
 cc_toolchain_import(
     name = "llvm_libunwind",
-    hdrs = ["lib/clang/12.0.0/include/unwind.h"],
-    includes = ["lib/clang/12.0.0/include"],
+    hdrs = glob(["lib/clang/*/include/unwind.h"]),
+    includes = glob(["lib/clang/*/include"]),
     runtime_path = "/usr/lib/x86_64-linux-gnu",
     shared_library = "lib/libunwind.so",
-    static_library = "lib/libunwind.a",
+    static_library = "lib/x86_64-unknown-linux-gnu/libunwind.a",
     target_compatible_with = select({
         "@platforms//os:linux": ["@platforms//cpu:x86_64"],
         "//conditions:default": ["@platforms//:incompatible"],
@@ -65,9 +65,9 @@ cc_toolchain_import(
 
 cc_toolchain_import(
     name = "llvm_libcxx",
-    hdrs = glob(["include/c++/v1/**"]),
+    hdrs = glob(["include/c++/v1/**", "include/x86_64-unknown-linux-gnu/c++/v1/**"]),
     includes = ["include/c++/v1"],
-    static_library = "lib/libc++.a",
+    static_library = "lib/x86_64-unknown-linux-gnu/libc++.a",
     target_compatible_with = select({
         "@platforms//os:linux": ["@platforms//cpu:x86_64"],
         "//conditions:default": ["@platforms//:incompatible"],
@@ -83,7 +83,7 @@ cc_toolchain_import(
     name = "llvm_libcxx_abi",
     hdrs = glob(["include/c++/v1/**"]),
     includes = ["include/c++/v1"],
-    static_library = "lib/libc++abi.a",
+    static_library = "lib/x86_64-unknown-linux-gnu/libc++abi.a",
     target_compatible_with = select({
         "@platforms//os:linux": ["@platforms//cpu:x86_64"],
         "//conditions:default": ["@platforms//:incompatible"],
@@ -98,15 +98,16 @@ cc_toolchain_import(
 cc_toolchain_import(
     name = "llvm_libclang_rt",
     hdrs = glob([
-        "lib/clang/12.0.0/*.h",
-        "lib/clang/12.0.0/include/*.h",
-        "lib/clang/12.0.0/include/**/*.h",
+        "lib/clang/*/*.h",
+        "lib/clang/*/include/*.h",
+        "lib/clang/*/include/**/*.h",
     ]),
-    includes = [
-        "lib/clang/12.0.0",
-        "lib/clang/12.0.0/include",
-    ],
-    static_library = "lib/clang/12.0.0/lib/linux/libclang_rt.builtins-x86_64.a",
+    includes = glob([
+        "lib/clang/*",
+        "lib/clang/*/include",
+    ]),
+    # TODO: Last place where the version is hardcoded :/
+    static_library = "lib/clang/15.0.6/lib/x86_64-unknown-linux-gnu/libclang_rt.builtins.a",
     target_compatible_with = select({
         "@platforms//os:linux": ["@platforms//cpu:x86_64"],
         "//conditions:default": ["@platforms//:incompatible"],

--- a/third_party/clang_llvm_x86_64_linux_gnu_ubuntu.BUILD
+++ b/third_party/clang_llvm_x86_64_linux_gnu_ubuntu.BUILD
@@ -64,8 +64,25 @@ cc_toolchain_import(
 )
 
 cc_toolchain_import(
+    name = "llvm_libstddef",
+    hdrs = glob(["lib/clang/*/include/stddef.h"]),
+    includes = ["lib/clang/15.0.6/include"],
+    # runtime_path = "/usr/lib/x86_64-linux-gnu",
+    # shared_library = "lib/libunwind.so",
+    # static_library = "lib/x86_64-unknown-linux-gnu/libunwind.a",
+    target_compatible_with = select({
+        "@platforms//os:linux": ["@platforms//cpu:x86_64"],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["@rules_cc_toolchain//config:__pkg__"],
+    deps = [
+        "@rules_cc_toolchain_config//:libc",
+    ],
+)
+
+cc_toolchain_import(
     name = "llvm_libcxx",
-    hdrs = glob(["include/c++/v1/**", "include/x86_64-unknown-linux-gnu/c++/v1/**"]),
+    hdrs = glob(["include/c++/v1/**"]),
     includes = ["include/c++/v1"],
     static_library = "lib/x86_64-unknown-linux-gnu/libc++.a",
     target_compatible_with = select({
@@ -74,9 +91,23 @@ cc_toolchain_import(
     }),
     visibility = ["@rules_cc_toolchain//config:__pkg__"],
     deps = [
+        # TODO: Add more indirection.
+        ":llvm_config_site",
+        ":llvm_libstddef",
         "@rules_cc_toolchain_config//:libc",
         "@rules_cc_toolchain_config//:libunwind",
     ],
+)
+
+cc_toolchain_import(
+    name = "llvm_config_site",
+    hdrs = ["include/x86_64-unknown-linux-gnu/c++/v1/__config_site"],
+    includes = ["include/x86_64-unknown-linux-gnu/c++/v1"],
+    target_compatible_with = select({
+        "@platforms//os:linux": ["@platforms//cpu:x86_64"],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["@rules_cc_toolchain//config:__pkg__"],
 )
 
 cc_toolchain_import(

--- a/third_party/test_repos.bzl
+++ b/third_party/test_repos.bzl
@@ -35,9 +35,9 @@ def test_repos():
     if "com_github_google_benchmark" not in native.existing_rules():
         http_archive(
             name = "com_github_google_benchmark",
-            sha256 = "3c6a165b6ecc948967a1ead710d4a181d7b0fbcaa183ef7ea84604994966221a",
-            strip_prefix = "benchmark-1.5.0",
-            urls = ["https://github.com/google/benchmark/archive/v1.5.0.tar.gz"],
+            sha256 = "fc5d1e987dbf9419b049f1806da2d96b0c52dc452bef70d5669791bfccf28e56",
+            strip_prefix = "benchmark-1.7.1",
+            urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.7.1.tar.gz"],
         )
 
     if "com_google_absl" not in native.existing_rules():

--- a/third_party/test_repos.bzl
+++ b/third_party/test_repos.bzl
@@ -35,7 +35,7 @@ def test_repos():
     if "com_github_google_benchmark" not in native.existing_rules():
         http_archive(
             name = "com_github_google_benchmark",
-            sha256 = "fc5d1e987dbf9419b049f1806da2d96b0c52dc452bef70d5669791bfccf28e56",
+            sha256 = "6430e4092653380d9dc4ccb45a1e2dc9259d581f4866dc0759713126056bc1d7",
             strip_prefix = "benchmark-1.7.1",
             urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.7.1.tar.gz"],
         )

--- a/third_party/test_repos.bzl
+++ b/third_party/test_repos.bzl
@@ -13,6 +13,15 @@ def test_repos():
             sha256 = "cd6730ed53a002c56ce4e2f396ba3b3be262fd7cb68339f0377a45e8227fe332",
         )
 
+    if "com_googlesource_code_re2" not in native.existing_rules():
+        # Dependency of googletest
+        http_archive(
+            name = "com_googlesource_code_re2",  # 2022-12-21T14:29:10Z
+            sha256 = "b9ce3a51beebb38534d11d40f8928d40509b9e18a735f6a4a97ad3d014c87cb5",
+            strip_prefix = "re2-d0b1f8f2ecc2ea74956c7608b6f915175314ff0e",
+            urls = ["https://github.com/google/re2/archive/d0b1f8f2ecc2ea74956c7608b6f915175314ff0e.zip"],
+        )
+
     if "com_google_googletest" not in native.existing_rules():
         http_archive(
             name = "com_google_googletest",

--- a/third_party/test_repos.bzl
+++ b/third_party/test_repos.bzl
@@ -16,10 +16,10 @@ def test_repos():
     if "com_google_googletest" not in native.existing_rules():
         http_archive(
             name = "com_google_googletest",
-            sha256 = "ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363",
-            strip_prefix = "googletest-1.13.0",
+            sha256 = "564f89e499a99e85a481122d22b2e3e7a8f6e8b8809a64363f96edd2b2ee2979",
+            strip_prefix = "googletest-1.12.0",
             urls = [
-                "https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz",
+                "https://github.com/google/googletest/archive/refs/tags/v1.12.0.tar.gz",
             ],
         )
 

--- a/third_party/test_repos.bzl
+++ b/third_party/test_repos.bzl
@@ -16,9 +16,11 @@ def test_repos():
     if "com_google_googletest" not in native.existing_rules():
         http_archive(
             name = "com_google_googletest",
-            sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
-            strip_prefix = "googletest-release-1.10.0",
-            urls = ["https://github.com/google/googletest/archive/release-1.10.0.tar.gz"],
+            sha256 = "ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363",
+            strip_prefix = "googletest-1.13.0",
+            urls = [
+                "https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz",
+            ],
         )
 
     if "com_github_google_benchmark" not in native.existing_rules():
@@ -32,9 +34,9 @@ def test_repos():
     if "com_google_absl" not in native.existing_rules():
         http_archive(
             name = "com_google_absl",
-            sha256 = "0db0d26f43ba6806a8a3338da3e646bb581f0ca5359b3a201d8fb8e4752fd5f8",
-            strip_prefix = "abseil-cpp-20200225.1",
-            urls = ["https://github.com/abseil/abseil-cpp/archive/20200225.1.tar.gz"],
+            sha256 = "3ea49a7d97421b88a8c48a0de16c16048e17725c7ec0f1d3ea2683a2a75adc21",
+            strip_prefix = "abseil-cpp-20230125.0",
+            urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.0.tar.gz"],
         )
 
     if "com_google_protobuf" not in native.existing_rules():

--- a/tools/clang_tidy/clang_tidy.bzl
+++ b/tools/clang_tidy/clang_tidy.bzl
@@ -156,7 +156,7 @@ clang_tidy_aspect = aspect(
     attrs = {
         "_clang_tidy": attr.label(
             allow_single_file = True,
-            default = "@clang_llvm_12_00_x86_64_linux_gnu_ubuntu_16_04//:bin/clang-tidy",
+            default = "@clang_llvm_x86_64_linux_gnu_ubuntu//:bin/clang-tidy",
             cfg = "exec",
             executable = True,
         ),


### PR DESCRIPTION
I also removed clang version number strings ("12.0.0") where possible to make similar upgrades less painful in the future.  Unfortunately, there's a limit to what can be achieved here, because the file structure of clang releases is not actually stable (so just replacing the version number with a wildcard is not generally enough).

Tests don't build yet.